### PR TITLE
fix: change header level of JSON entry in German help

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current/setup-hc/edit-metadata-config/2015-02-10-theme-edit-metadata.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/setup-hc/edit-metadata-config/2015-02-10-theme-edit-metadata.md
@@ -2960,7 +2960,7 @@ Im folgenden Beispiel wird ein gmx:Anchor als ``defaultValue`` und dem Feld ``en
                   }
               ],
 
-#### Hinzufügen von JSON-Werten in String-Feldern
+### Hinzufügen von JSON-Werten in String-Feldern
 
 JSON-Werte können im Metadaten-Editor zu String-Feldern hinzugefügt werden. Die JSON-Werte müssen maskiert werden, bevor sie der Metadatenkonfiguration hinzugefügt werden. Im folgenden Beispiel wird ein JSON-Wert als ``defaultValue`` und dem Feld ``enumValues`` hinzugefügt.
 


### PR DESCRIPTION
With the current level, it does not appear in the index of the help on the top right

HCO-54