### PR TITLE
build: deploy PR builds to staging environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and deploy to staging environment
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -21,3 +21,21 @@ jobs:
         run: |
           npm ci
           npm run build
+
+      - name: Prepare SSH key and known hosts
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy 🚀
+        run: |
+          rsync -rSlh --stats --delete build/ ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:${{ secrets.SSH_WEBPATH }}/${{ github.event.number }}
+
+      - name: Add comment to PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            The output of the build is available at http://staging.docs.wetransform.eu/pr/${{ github.event.number }}
+          comment-tag: staging-url

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,32 @@
+name: Clean up staging environment
+
+on:
+  pull_request:
+    branches: [ master ]
+    types:
+      - closed
+
+jobs:
+  clean-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepare SSH key and known hosts
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Remove PR deployment
+        run: |
+          mkdir -p /tmp/empty
+          rsync -a --delete /tmp/empty/ ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:${{ secrets.SSH_WEBPATH }}/${{ github.event.number }}
+
+      - name: Remove comment from PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          comment-tag: staging-url
+          mode: delete


### PR DESCRIPTION
Extend GitHub Actions to automatically deploy the build output of a PR to a staging environment under a unique path.

To preserve disk space, the deployment is removed when the PR is either merged or closed.

ING-4710