### PR TITLE
ci(renovate): handle cheerio upgrades separately

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,5 +7,11 @@
   lockFileMaintenance: {
     enabled: true,
   },
+  packageRules: [
+    {
+      matchPackageNames: ['cheeriojs/cheerio'],
+      groupName: 'cheerio'
+    },
+  ],
   rangeStrategy: 'bump',
 }


### PR DESCRIPTION
Upgrading cheerio currently breaks support for the search plugin, so the upgrade is handled separately for now to allow renovate to update other dependencies.