### PR TITLE
Update sld-tutorial (ING-2467, ING-4028)

### DIFF
--- a/docs/tutorials/2018-05-03-sld-tutorial.md
+++ b/docs/tutorials/2018-05-03-sld-tutorial.md
@@ -61,7 +61,7 @@ You must add '/text()' after the referenced property in TextSymbolizer Label tag
 
 ### **Adding layer names, layer titles and rule titles to a Styled Layer Descriptor file**
 
-Layer names and layer titles can be added to SLDs. Layer names cannot contain white spaces or colons. The INSPIRE layer name for the Protected Sites feature type is ```PS.ProtectedSite```. Layer names can be added to the NamedLayer.Name element:
+Layer names and layer titles can be added to SLDs. The INSPIRE layer name for the Protected Sites feature type is ```PS.ProtectedSite```. Layer names can be added to the NamedLayer.Name element:
 
 ```xml
 	<NamedLayer>

--- a/i18n/cs/docusaurus-plugin-content-docs/current/tutorials/2018-05-03-sld-tutorial.md
+++ b/i18n/cs/docusaurus-plugin-content-docs/current/tutorials/2018-05-03-sld-tutorial.md
@@ -61,7 +61,7 @@ You must add '/text()' after the referenced property in TextSymbolizer Label tag
 
 ### **Přidání názvů vrstev, názvů vrstev a názvů pravidel do souboru Stylizovaný deskriptor vrstvy**
 
-Do SLD lze přidat názvy vrstev a názvy vrstev. Názvy vrstev nemohou obsahovat mezery. Název vrstvy INSPIRE pro typ funkce Chráněné lokality je ```PS.ProtectedSite```. Názvy vrstev lze přidat do prvku NamedLayer.Name element:
+Do SLD lze přidat názvy vrstev a názvy vrstev. Název vrstvy INSPIRE pro typ funkce Chráněné lokality je ```PS.ProtectedSite```. Názvy vrstev lze přidat do prvku NamedLayer.Name element:
 
 ```xml
 	<NamedLayer>

--- a/i18n/de/docusaurus-plugin-content-docs/current/tutorials/2018-05-03-sld-tutorial.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/tutorials/2018-05-03-sld-tutorial.md
@@ -61,7 +61,7 @@ Sie müssen '/text()' hinter der referenzierten Eigenschaft in TextSymbolizer La
 
 ### **Hinzufügen von Namen für Layer sowie Titeln für Layer und Regeln zu einer Styled Layer Descriptor-Datei** ###
 
-Namen und Titel für Layer können zu SLD-Dateien hinzugefügt werden. Dabei dürfen Layernamen keine Leerzeichen oder Doppelpunkte enthalten. Der von INSPIRE vorgesehene Layername für Schutzgebiete ist beispielsweise ```PS.ProtectedSite```. Layernamen können im Element NamedLayer.Name hinzugefügt werden.
+Namen und Titel für Layer können zu SLD-Dateien hinzugefügt werden. Der von INSPIRE vorgesehene Layername für Schutzgebiete ist beispielsweise ```PS.ProtectedSite```. Layernamen können im Element NamedLayer.Name hinzugefügt werden.
 
 ```xml
 	<NamedLayer>


### PR DESCRIPTION
With ING-2467 and ING-4028 it is now possible to use white spaces and colons in sld layer names.
The corresponding warning in the documentation can therefore be removed.

Testdataset: https://haleconnect.com/#/dataset/org/1290/4071d31d-18de-48b1-b7db-aa4d4fac2c8b/overview
Test-Theme: https://haleconnect.com/#/theme/SVC-2104XPlanGM-1749111040669/viewservices

Result in MapView: 
![Screenshot 2025-06-05 101941](https://github.com/user-attachments/assets/e2aa86a4-e9ca-453e-8a55-37d81c99d746)
