### PR TITLE
docs: add restriction on shapefiles

### DIFF
--- a/docs/create-manage-datasets/create-dataset/2015-01-10-dataset-create.md
+++ b/docs/create-manage-datasets/create-dataset/2015-01-10-dataset-create.md
@@ -15,6 +15,7 @@ hale»connect currently supports a range of file formats which can be used to cr
   * Supported vector data formats include \*.gml, \*gpkg and \*.shp
   * Multiple \*.shp files can be uploaded to create a data set
   * Publication of \*.shp files in which the first object does not have a geometry is currently not supported
+  * Publication of multiple \*.shp files containing the same type is currently not supported
   * One or more  \*.gml files per data set is supported
     * INSPIRE, 3A, CityGML, XPlanung and ISYBAU are fully supported
   * \*.gml files containing the element gml:GenericMetaData, an empty gml:boundedBy element or arc geometries are currently not supported

--- a/i18n/de/docusaurus-plugin-content-docs/current/create-manage-datasets/create-dataset/2015-01-10-dataset-create.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/create-manage-datasets/create-dataset/2015-01-10-dataset-create.md
@@ -21,6 +21,7 @@ Die Größenbeschränkung für Anhänge auf haleconnect.com liegt bei 750 MB.
   * hale»connect unterstützt \*.gml, \*gpkg und \*.shp.
   * Es können mehrere \*.shp-Dateien hochgeladen werden, um einen Datensatz anzulegen.
   * Die Publikation von \*.shp-Dateien, deren erstes Objekt keine Geometrie hat, wird derzeit nicht unterstützt.
+  * Die Publikation von mehreren \*.shp-Dateien, die den gleichen Typen enthalten, wird derzeit nicht unterstützt.
   * Es können mehrere \*.gml-Dateien hochgeladen werden, um einen Datensatz anzulegen.
     * Die Standards INSPIRE, 3A, CityGML, XPlanung und ISYBAU werden vollständig unterstützt.
   * \*.gml-Dateien, die ein gml:GenericMetaData-Element, ein leeres gml:boundedBy-Element oder Arc-Geometrien enthalten, werden derzeit nicht unterstüzt.


### PR DESCRIPTION
According to [this Slack thread](https://wetransform.slack.com/archives/C1G8ZA1QX/p1755262166213409) it is currently not supported to publish multiple shapefiles containing the same type.

WGS-3342