### PR TITLE
docs: remove info on geopackage as transformation source/target

### DIFF
--- a/docs/create-manage-datasets/create-dataset/2015-01-10-dataset-create.md
+++ b/docs/create-manage-datasets/create-dataset/2015-01-10-dataset-create.md
@@ -21,7 +21,6 @@ hale»connect currently supports a range of file formats which can be used to cr
   * \*.gml files containing the element gml:GenericMetaData, an empty gml:boundedBy element or arc geometries are currently not supported
   * One or more  \*.gpkg files per data set is supported
     * \*.gpkg schemas can be exported from hale»studio as \*.json.hsd files for use in hale»connect
-    * \*.gpkg is supported as source and target in online transformation configurations
   * The publication of 3D data is supported.
 
 **Non-spatial data**

--- a/i18n/de/docusaurus-plugin-content-docs/current/create-manage-datasets/create-dataset/2015-01-10-dataset-create.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/create-manage-datasets/create-dataset/2015-01-10-dataset-create.md
@@ -26,7 +26,6 @@ Die Größenbeschränkung für Anhänge auf haleconnect.com liegt bei 750 MB.
     * Die Standards INSPIRE, 3A, CityGML, XPlanung und ISYBAU werden vollständig unterstützt.
   * \*.gml-Dateien, die ein gml:GenericMetaData-Element, ein leeres gml:boundedBy-Element oder Arc-Geometrien enthalten, werden derzeit nicht unterstüzt.
   * Es können mehrere \*.gpkg-Dateien hochgeladen werden, um einen Datensatz anzulegen.
-      * GeoPackages werden als Quell- und Zieldaten zur Verwendung in hale»connect Transformationsprojekten unterstützt.
       * \*.gpkg-Schemas können aus hale»studio als \*.json.hsd-Dateien zur Verwendung in hale»connect exportiert werden.
   * Die Publikation von 3D-Dateien wird unterstützt.
 


### PR DESCRIPTION
Geopackages are supported for publications such as other data formats we support according to [this Slack thread](https://wetransform.slack.com/archives/C1G8ZA1QX/p1755782096736159). It should therefore not be mentioned explicitely to avoid confusion.

PRD-20